### PR TITLE
Improve Performance and Reduce memory usage

### DIFF
--- a/pylmnn/utils.py
+++ b/pylmnn/utils.py
@@ -1,6 +1,37 @@
+import sys
+import time
+import datetime
+import math
 import numpy as np
 from sklearn.utils.extmath import row_norms, safe_sparse_dot
 
+def eprint(message):
+    ts = datetime.datetime.now().isoformat()
+    print(ts+" "+message, file=sys.stderr)
+
+class ReservoirSample:
+    def __init__(self, k, random_state):
+        self.random_state = random_state
+        self.reservoir = []
+        self.w = math.exp(math.log(self.random_state.rand())/k)
+        self.k = k
+        self.i = 0
+        self.next_i = self.k + math.floor(
+                math.log(self.random_state.random())/math.log(1-self.w)) + 1
+
+    def extend(self, s):
+        for i, v in enumerate(s, start=self.i):
+            # initialize reservoir array
+            if i < self.k:
+                self.reservoir.append(v)
+            elif i == self.next_i:
+                #replace a random item of the reservoir with item i
+                self.reservoir[self.random_state.randint(0,self.k)] = v
+                self.w = self.w * math.exp(math.log(self.random_state.random())/self.k)
+                self.next_i = (i + 1 +
+                        math.floor(math.log(self.random_state.random())/math.log(1-self.w)))
+
+        self.i = i
 
 def _euclidean_distances_without_checks(X, Y=None, Y_norm_squared=None,
                                         squared=False, X_norm_squared=None,


### PR DESCRIPTION
Reduce memory usage and improve performance by:
* use pairwise_distances_chunked which is much faster than constructing NearestNeighbors and using it for kneighbors (see plot below)
* sample impostor indices using a reservoir sampler instead of sampling after the fact

Below is a comparison of different methods to select target neighbors. A polynomial degree 2 trendline is included. NearestNeighbors is the original implementation that constructs a NearestNeighbors from sklearn and then uses kneighbors. Dualtree forces the use of a ball_tree and uses the dual_tree option for finding kneighbors. pairwise_distances_chunked is the implementation from this PR that uses sklearn.metrics.pairwise_distances_chunked directly. The pairwise_distances_chunked method is much faster than constructing the NearestNeighbors object and using it's kneighbors method to find the target neighbors.

Note, the dimenstionality of this dataset is very high, much higher than the 15 cutoff NearestNeighbors uses to switch to brute force.

![image](https://user-images.githubusercontent.com/114309/106205892-1452bf80-6174-11eb-90f6-710e532f9c1a.png)

The reservoir sampling is used to do on-line uniform random sampling from the set of imposters, rather than sampling after all imposters have been selected. Holding all impostors for all nodes turns out to be very memory intensive for large datasets, so on-line sampling helps a lot.

Finally, I moved all the prints to write to stderr instead of stdout. Having logging is useful, having it write to stdout can pollute application specific results that makes it hard to use the verbose option in some settings.

Tests still pass, although I had to reduce the precision of one of the tests from 6 digits to 5. I also made the tests run with sklearn 0.24 which moved the test utils to a private module. I think most of those are avialable in numpy, but I wasn't sure about all of them, so I just left it and have a try/import/except/other import around those.